### PR TITLE
Regenerate the IDs for external resources

### DIFF
--- a/godot/game/card_spawner/card_spawner.tscn
+++ b/godot/game/card_spawner/card_spawner.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://bjys70k0ko3s4" path="res://game/card_spawner/card_spawner_inner_wheel.svg" id="3_c5i5m"]
 [ext_resource type="Texture2D" uid="uid://cfsj8fjs2p5jp" path="res://game/card_spawner/card_spawner_core.svg" id="4_f6ax0"]
 [ext_resource type="Texture2D" uid="uid://gjklyh8245hr" path="res://shared/effect_ellipse.svg" id="5_urwxv"]
-[ext_resource type="AudioStream" uid="uid://56vy02tk4fp7" path="res://game/card_spawner/card_spawn.wav" id="6_gs6bs"]
+[ext_resource type="AudioStream" uid="uid://dltq2lgjdgq6m" path="res://game/card_spawner/card_spawn.wav" id="6_gs6bs"]
 
 [sub_resource type="Animation" id="Animation_1nxe6"]
 length = 0.001

--- a/godot/game/game.tscn
+++ b/godot/game/game.tscn
@@ -9,7 +9,7 @@
 [ext_resource type="PackedScene" uid="uid://dqrb0owc04n30" path="res://game/balloon/balloon.tscn" id="5_jytc0"]
 [ext_resource type="PackedScene" uid="uid://bf8syl2igprqk" path="res://game/ui/healthbar.tscn" id="6_hh28r"]
 [ext_resource type="PackedScene" uid="uid://dr0frejjolbwb" path="res://game/cave_segment/cave_segment.tscn" id="6_uxkq5"]
-[ext_resource type="AudioStream" uid="uid://cmg2rvyvgl6gu" path="res://game/cave_background.ogg" id="10_yhmmh"]
+[ext_resource type="AudioStream" uid="uid://dxss2rjtux53e" path="res://game/cave_background.ogg" id="10_yhmmh"]
 
 [node name="Game" type="Node2D"]
 script = ExtResource("1_ak8ma")


### PR DESCRIPTION
Godot 4.0.3 fixes a bug that caused IDs for external resources to be regenerated over and over again.